### PR TITLE
Make Docker workflow self-contained

### DIFF
--- a/reproducibility/Dockerfile
+++ b/reproducibility/Dockerfile
@@ -36,8 +36,9 @@ RUN conda create -n threatrace_env python=3.6.13 -y && \
         torch-sparse==0.6.12 \
         torch-spline-conv==1.2.1 \
         -f https://data.pyg.org/whl/torch-1.9.1+cu102.html && \
-    conda run -n threatrace_env pip install torch-geometric==1.4.3 && \
-    conda clean -a
+    conda run -n threatrace_env python -m pip install torch-geometric==1.4.3 && \
+    conda run -n threatrace_env python -m pip install "gdown==4.7.3" && \
+    conda clean -a -y
 
 # Correct the incompatibility issue in the torch-geometric library
 RUN sed -i 's/from torch._six import container_abcs, string_classes, int_classes/import collections.abc as container_abcs\nstring_classes = str\nint_classes = int/' \

--- a/reproducibility/Dockerfile
+++ b/reproducibility/Dockerfile
@@ -30,7 +30,7 @@ RUN conda create -n threatrace_env python=3.6.13 -y && \
         cudatoolkit=10.2 \
         psutil \
         -c pytorch && \
-    conda run -n threatrace_env pip install \
+    conda run -n threatrace_env python -m pip install \
         torch-cluster==1.5.9 \
         torch-scatter==2.0.9 \
         torch-sparse==0.6.12 \

--- a/reproducibility/README.md
+++ b/reproducibility/README.md
@@ -21,9 +21,9 @@
 
     ```
     conda install -y pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cudatoolkit=10.2 psutil -c pytorch
-    pip install torch-cluster==1.5.9 torch-scatter==2.0.9 torch-sparse==0.6.12 torch-spline-conv==1.2.1 -f https://data.pyg.org/whl/torch-1.9.1+cu102.html
-    pip install torch-geometric==1.4.3    
-    pip install gdown==4.7.3
+    python -m pip install torch-cluster==1.5.9 torch-scatter==2.0.9 torch-sparse==0.6.12 torch-spline-conv==1.2.1 -f https://data.pyg.org/whl/torch-1.9.1+cu102.html
+    python -m pip install torch-geometric==1.4.3
+    python -m pip install gdown==4.7.3
     ```
 
 7) Alternatively, we have provided a [Dockerfile](./Dockerfile) for ease.

--- a/reproducibility/README.md
+++ b/reproducibility/README.md
@@ -21,8 +21,9 @@
 
     ```
     conda install -y pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cudatoolkit=10.2 psutil -c pytorch
-    pip install -y torch-cluster==1.5.9 torch-scatter==2.0.9 torch-sparse==0.6.12 torch-spline-conv==1.2.1 -f https://data.pyg.org/whl/torch-1.9.1+cu102.html
+    pip install torch-cluster==1.5.9 torch-scatter==2.0.9 torch-sparse==0.6.12 torch-spline-conv==1.2.1 -f https://data.pyg.org/whl/torch-1.9.1+cu102.html
     pip install torch-geometric==1.4.3    
+    pip install gdown==4.7.3
     ```
 
 7) Alternatively, we have provided a [Dockerfile](./Dockerfile) for ease.
@@ -30,20 +31,17 @@
     1) Docker build:
 
         ```
-        docker build -t threatrace .
+        docker build -f reproducibility/Dockerfile -t threatrace .
         ```
 
     2) Navigate to the downloaded / cloned threaTrace repository and run the following command to start the container with the current directory (i.e. threaTrace's repository) mounted (inside the workspace folder of the container)
 
         ```
-        docker run -it -v "$(pwd)":/workspace threatrace
+        docker run --rm -it -v "$(pwd)":/workspace -w /workspace threatrace bash
         ```
 
-    3) To find the current / mounted directory inside the container:
-
-        ```
-        cd workspace
-        ```
+    The container opens directly in `/workspace`, which contains the mounted
+    threaTrace repository.
 
 8) Follow the instructions mentioned in [threaTrace's readme](https://github.com/threaTrace-detector/threaTrace) to download the datasets and run the code.
 

--- a/reproducibility/automation/README.md
+++ b/reproducibility/automation/README.md
@@ -104,12 +104,8 @@ python reproducibility/automation/run.py list --json
 The Dockerfile installs the original CPU/CUDA-capable package versions and
 patches the known `torch._six` incompatibility in torch-geometric.
 
-The Dockerfile does not install `gdown`. Install it inside the container before
-using automatic DARPA downloads, or manually provide the DARPA archives:
-
-```bash
-python -m pip install "gdown==4.7.3"
-```
+The Dockerfile installs `gdown==4.7.3`, so automatic DARPA downloads use the
+same downloader version as the Conda setup.
 
 ### CPU and CUDA behavior
 


### PR DESCRIPTION
## What changed

- Installed `gdown==4.7.3` in the threaTrace Conda environment during image creation.
- Made Conda cleanup non-interactive.
- Removed the invalid `pip install -y` command.
- Corrected the repository-root Docker build command.
- Standardized the container command and documented that it opens directly in `/workspace`.
- Updated the automation README to reflect that `gdown` is included.

## Why

The Docker workflow should run the automated download pipeline without an extra package-install step and should match the established MAGIC mounting and working-directory pattern.

## Validation

- Ran `git diff --check` successfully.
- Confirmed the stale Docker and pip commands no longer occur in the reproducibility documentation.
- Statically reviewed the Dockerfile; an image build was not possible because this machine cannot access the Docker daemon.

Ubuntu 16.04 and the original threaTrace dependency versions are intentionally unchanged.